### PR TITLE
Improve ID validation on CRUD routes

### DIFF
--- a/src/routers/placeRouter.ts
+++ b/src/routers/placeRouter.ts
@@ -98,26 +98,11 @@ export const placeRouter = router({
    */
   getById: publicProcedure
     .input(
-      z.union([
-        z.number().int().positive(),
-        z.string().transform((val) => {
-          const num = Number(val);
-          if (isNaN(num)) throw new Error('ID must be a valid number');
-          return num;
+      z.object({
+        id: z.coerce.number().int().positive().refine((val) => !isNaN(val), {
+          message: 'ID must be a valid number',
         }),
-        z
-          .object({
-            id: z.union([
-              z.number().int().positive(),
-              z.string().transform((val) => {
-                const num = Number(val);
-                if (isNaN(num)) throw new Error('ID must be a valid number');
-                return num;
-              }),
-            ]),
-          })
-          .transform((val) => val.id),
-      ])
+      })
     )
     .query(async ({ ctx, input }) => {
       try {
@@ -131,7 +116,7 @@ export const placeRouter = router({
         }
 
         const placeService = new PlaceService(ctx.prisma);
-        const place = await placeService.getPlaceById(input);
+        const place = await placeService.getPlaceById(input.id);
 
         if (!place) {
           console.log('Place not found for id:', input);
@@ -385,19 +370,17 @@ export const placeRouter = router({
     .use(isAuthenticated)
     .use(isAdmin)
     .input(
-      z
-        .number()
-        .int()
-        .positive()
-        .refine((val) => !isNaN(val), {
+      z.object({
+        id: z.coerce.number().int().positive().refine((val) => !isNaN(val), {
           message: 'ID must be a valid number',
-        })
+        }),
+      })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         console.log('delete input:', input);
 
-        if (!input) {
+        if (!input.id) {
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: 'ID is required',
@@ -405,7 +388,7 @@ export const placeRouter = router({
         }
 
         const placeService = new PlaceService(ctx.prisma);
-        const place = await placeService.getPlaceById(input);
+        const place = await placeService.getPlaceById(input.id);
 
         if (!place) {
           console.log('Place not found for id:', input);
@@ -415,7 +398,7 @@ export const placeRouter = router({
           });
         }
 
-        return placeService.deletePlace(input);
+        return placeService.deletePlace(input.id);
       } catch (error) {
         console.error('Error in delete:', {
           error,

--- a/src/routers/reviewRouter.ts
+++ b/src/routers/reviewRouter.ts
@@ -154,26 +154,24 @@ export const reviewRouter = router({
   delete: publicProcedure
     .use(isAuthenticated)
     .input(
-      z
-        .number()
-        .int()
-        .positive()
-        .refine((val) => !isNaN(val), {
+      z.object({
+        id: z.coerce.number().int().positive().refine((val) => !isNaN(val), {
           message: 'ID must be a valid number',
-        })
+        }),
+      })
     )
     .mutation(async ({ input }) => {
       try {
         console.log('delete input:', input);
 
-        if (!input) {
+        if (!input.id) {
           throw new TRPCError({
             code: 'BAD_REQUEST',
             message: 'ID is required',
           });
         }
 
-        const review = await reviewService.getReviewById(input);
+        const review = await reviewService.getReviewById(input.id);
 
         if (!review) {
           console.log('Review not found for id:', input);
@@ -183,7 +181,7 @@ export const reviewRouter = router({
           });
         }
 
-        return await reviewService.deleteReview(input);
+        return await reviewService.deleteReview(input.id);
       } catch (error) {
         console.error('Error in delete:', {
           error,

--- a/src/routers/taxiRouter.ts
+++ b/src/routers/taxiRouter.ts
@@ -107,7 +107,13 @@ export const taxiRouter = router({
    *               $ref: '#/components/schemas/Error'
    */
   getById: publicProcedure
-    .input(z.object({ id: z.coerce.number() }))
+    .input(
+      z.object({
+        id: z.coerce.number().int().positive().refine((val) => !isNaN(val), {
+          message: 'ID must be a valid number',
+        }),
+      })
+    )
     .query(async ({ ctx, input }) => {
       try {
         const taxiService = new TaxiService(ctx.prisma);
@@ -360,10 +366,16 @@ export const taxiRouter = router({
   delete: publicProcedure
     .use(isAuthenticated)
     .use(isAdmin)
-    .input(z.number())
+    .input(
+      z.object({
+        id: z.coerce.number().int().positive().refine((val) => !isNaN(val), {
+          message: 'ID must be a valid number',
+        }),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const taxiService = new TaxiService(ctx.prisma);
-      return taxiService.deleteTaxi(input);
+      return taxiService.deleteTaxi(input.id);
     }),
 
   search: publicProcedure

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcrypt';
 import { generateToken, generateRefreshToken, verifyToken } from '../utils/jwt';
 import { UserRole } from '../middleware/authMiddleware';
-import { prisma } from '../prisma';
+import prisma from '../prisma';
 import type { PrismaClient } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 

--- a/src/trpc.ts
+++ b/src/trpc.ts
@@ -1,6 +1,6 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import { CreateExpressContextOptions } from '@trpc/server/adapters/express';
-import { prisma } from './prisma';
+import prisma from './prisma';
 import { UserRole } from './middleware/authMiddleware';
 import { verifyToken } from './utils/jwt';
 import { ZodError } from 'zod';


### PR DESCRIPTION
## Summary
- validate numeric ID inputs in taxi, place and review routers
- use object payloads consistently for delete operations

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ed3a3c454832bae4e719bd5cd9ee4